### PR TITLE
match segment if remainingPath only consist of unknown qsParams

### DIFF
--- a/dist/amd/route-node.js
+++ b/dist/amd/route-node.js
@@ -192,12 +192,14 @@ define(['exports', 'module', 'path-parser'], function (exports, module, _pathPar
                             Object.keys(match).forEach(function (param) {
                                 return segments.params[param] = match[param];
                             });
-                            // If fully matched
-                            if (!remainingPath.length) {
-                                return {
-                                    v: segments
-                                };
-                            }
+
+                            if (!remainingPath.length || // fully matched
+                            remainingPath.indexOf('?') === 0 // we only got unmatched queryParams
+                            ) {
+                                    return {
+                                        v: segments
+                                    };
+                                }
                             // If no children to match against but unmatched path left
                             if (!child.children.length) {
                                 return {

--- a/dist/commonjs/route-node.js
+++ b/dist/commonjs/route-node.js
@@ -197,12 +197,14 @@ var RouteNode = (function () {
                         Object.keys(match).forEach(function (param) {
                             return segments.params[param] = match[param];
                         });
-                        // If fully matched
-                        if (!remainingPath.length) {
-                            return {
-                                v: segments
-                            };
-                        }
+
+                        if (!remainingPath.length || // fully matched
+                        remainingPath.indexOf('?') === 0 // we only got unmatched queryParams
+                        ) {
+                                return {
+                                    v: segments
+                                };
+                            }
                         // If no children to match against but unmatched path left
                         if (!child.children.length) {
                             return {

--- a/dist/umd/route-node.js
+++ b/dist/umd/route-node.js
@@ -204,12 +204,14 @@
                             Object.keys(match).forEach(function (param) {
                                 return segments.params[param] = match[param];
                             });
-                            // If fully matched
-                            if (!remainingPath.length) {
-                                return {
-                                    v: segments
-                                };
-                            }
+
+                            if (!remainingPath.length || // fully matched
+                            remainingPath.indexOf('?') === 0 // we only got unmatched queryParams
+                            ) {
+                                    return {
+                                        v: segments
+                                    };
+                                }
                             // If no children to match against but unmatched path left
                             if (!child.children.length) {
                                 return {

--- a/modules/RouteNode.js
+++ b/modules/RouteNode.js
@@ -157,9 +157,11 @@ export default class RouteNode {
                 if (match) {
                     segments.push(child)
                     Object.keys(match).forEach(param => segments.params[param] = match[param])
-                    // If fully matched
-                    if (!remainingPath.length) {
-                        return segments
+
+                    if (!remainingPath.length || // fully matched
+                        remainingPath.indexOf('?') === 0 // we only got unmatched queryParams
+                    ) {
+                      return segments
                     }
                     // If no children to match against but unmatched path left
                     if (!child.children.length) {

--- a/test/main.js
+++ b/test/main.js
@@ -196,9 +196,31 @@ describe('RouteNode', function () {
         withoutMeta(node.matchPath('/grand-parent/parent/child?nickname=gran&name=maman&age=3')).should.eql({name: 'grandParent.parent.child', params: {nickname: 'gran', name: 'maman', age: '3'}});
         withoutMeta(node.matchPath('/grand-parent/parent/child?nickname=gran&nickname=granny&name=maman&age=3')).should.eql({name: 'grandParent.parent.child', params: {nickname: ['gran', 'granny'], name: 'maman', age: '3'}});
 
-        // Unsuccessful matching
-        should.not.exist(node.matchPath('/grand-parent?nickname=gran&name=papa'));
-        should.not.exist(node.matchPath('/grand-parent/parent/child?nickname=gran&names=papa-maman'));
+        // still matching remainingPath only consist of unknown qsParams
+        node.matchPath('/grand-parent?nickname=gran&name=papa').should.eql({
+          _meta: {
+              grandParent: {
+                  nickname: 'query'
+              }
+          },
+          name: 'grandParent',
+          params: {nickname: 'gran'}
+        });
+        node.matchPath('/grand-parent/parent/child?nickname=gran&names=papa-maman').should.eql({
+          _meta: {
+              grandParent: {
+                  nickname: 'query'
+              },
+              'grandParent.parent': {
+                  name: 'query'
+              },
+              'grandParent.parent.child': {
+                  age: 'query'
+              }
+          },
+          name: 'grandParent.parent.child',
+          params: {nickname: 'gran'}
+        });
     });
 
     it('should find a nested route by matching a path with a splat', function () {


### PR DESCRIPTION
first let me thank you for router5...we right now try to move to router5 from react-router - but encounter one issue that makes it harder then needed for us.

1) we have a lot of querystring params across our app that acts more global then route specific, eg:
?lng=...
?debug=...

2) we got qs params that act more on some react component, like eg. preselecting some filter

both have in common, that we don't want them to be defined on the route.

sample: 
`router.addNode('userModify', '/user/modify/:userId')`
open `http://localhost/user/modifiy/1234?lng=de` would result in not found route.

this PR would change it so if a `remainingPath` in `getSegmentsMatchingPath` will be ignored if only consist of unmatched querystring params. Personally i think it would make more sense this way. See changed test in commit.