### PR TITLE
Allow partial matching with RouteNode

### DIFF
--- a/modules/RouteNode.js
+++ b/modules/RouteNode.js
@@ -184,7 +184,7 @@ export default class RouteNode {
     }
 
     getSegmentsMatchingPath(path, options) {
-        const { trailingSlash, strictQueryParams, strongMatching } = options;
+        const { trailingSlash, strictQueryParams, strongMatching, partialMatching } = options;
         let matchChildren = (nodes, pathSegment, segments) => {
             const isRoot = nodes.length === 1 && nodes[0].name === '';
             // for (child of node.children) {
@@ -235,7 +235,7 @@ export default class RouteNode {
                     const children = child.getNonAbsoluteChildren();
                     // If no children to match against but unmatched path left
                     if (!children.length) {
-                        return null;
+                        return partialMatching ? segments : null;
                     }
                     // Else: remaining path and children
                     return matchChildren(children, remainingPath, segments);
@@ -371,7 +371,7 @@ export default class RouteNode {
     }
 
     matchPath(path, options) {
-        const defaultOptions = { trailingSlash: false, strictQueryParams: true, strongMatching: true };
+        const defaultOptions = { trailingSlash: false, strictQueryParams: true, strongMatching: true, partialMatching: false };
         const opts = { ...defaultOptions, ...options };
         let matchedSegments = this.getSegmentsMatchingPath(path, opts);
 


### PR DESCRIPTION
Could be used with router5 using `router.rootNode.matchPath()`

I made this change via github UI, so writing tests here wasn't really convenient. If you really need me to write some tests for this, feel free to tell me, I'll then clone the repo locally and finish the PR properly.