### PR TITLE
Fix root path trimming

### DIFF
--- a/modules/RouteNode.js
+++ b/modules/RouteNode.js
@@ -328,7 +328,7 @@ export default class RouteNode {
 
         if (options.trailingSlash === true) {
             finalPath = /\/$/.test(path) ? path : `${path}/`;
-        } else if (options.trailingSlash === false) {
+        } else if (options.trailingSlash === false && path !== '/') {
             finalPath = /\/$/.test(path) ? path.slice(0, -1) : path;
         }
 

--- a/test/main.js
+++ b/test/main.js
@@ -518,12 +518,15 @@ describe('RouteNode', function () {
         const node = new RouteNode('', '', [
             new RouteNode('a', '/a', [
                 new RouteNode('b', '/?c')
-            ])
+            ]),
+            new RouteNode('c', '/?c')
         ]);
 
         node.buildPath('a.b', {}, { trailingSlash: false }).should.eql('/a');
         node.buildPath('a.b', { c: 1 }, { trailingSlash: false }).should.eql('/a?c=1');
+        node.buildPath('c', { c: 1 }, { trailingSlash: false }).should.eql('/?c=1');
     });
+
 });
 
 


### PR DESCRIPTION
The trailing slash of the path `/` (with optional query parameters) should not be trimmed, even when use `trailingSlash` is false.

This change solves #11 