### PR TITLE
Treat repeating slashes as pathless paths

### DIFF
--- a/dist/amd/route-node.js
+++ b/dist/amd/route-node.js
@@ -761,7 +761,7 @@ var RouteNode = function () {
                 strictQueryParams = options.strictQueryParams,
                 strongMatching = options.strongMatching;
 
-            var matchChildren = function matchChildren(nodes, pathSegment, segments) {
+            var matchChildren = function matchChildren(nodes, pathSegment, segments, consumedBefore) {
                 var isRoot = nodes.length === 1 && nodes[0].name === '';
                 // for (child of node.children) {
 
@@ -771,13 +771,20 @@ var RouteNode = function () {
                     // Partially match path
                     var match = void 0;
                     var remainingPath = void 0;
+                    var segment = pathSegment;
+
+                    if (consumedBefore === '/' && child.path === '/') {
+                        // when we encounter repeating slashes we add the slash
+                        // back to the URL to make it de facto pathless
+                        segment = '/' + pathSegment;
+                    }
 
                     if (!child.children.length) {
-                        match = child.parser.test(pathSegment, { trailingSlash: trailingSlash });
+                        match = child.parser.test(segment, { trailingSlash: trailingSlash });
                     }
 
                     if (!match) {
-                        match = child.parser.partialTest(pathSegment, { delimiter: strongMatching });
+                        match = child.parser.partialTest(segment, { delimiter: strongMatching });
                     }
 
                     if (match) {
@@ -787,13 +794,13 @@ var RouteNode = function () {
                             consumedPath = consumedPath.replace(/\/$/, '');
                         }
 
-                        remainingPath = pathSegment.replace(consumedPath, '');
+                        remainingPath = segment.replace(consumedPath, '');
 
                         if (trailingSlash && !child.children.length) {
                             remainingPath = remainingPath.replace(/^\/\?/, '?');
                         }
 
-                        var search = omit(getSearch(pathSegment.replace(consumedPath, '')), child.parser.queryParams.concat(child.parser.queryParamsBr));
+                        var search = omit(getSearch(segment.replace(consumedPath, '')), child.parser.queryParams.concat(child.parser.queryParamsBr));
                         remainingPath = getPath(remainingPath) + (search ? '?' + search : '');
                         if (trailingSlash && !isRoot && remainingPath === '/' && !/\/$/.test(consumedPath)) {
                             remainingPath = '';
@@ -833,7 +840,7 @@ var RouteNode = function () {
                         }
                         // Else: remaining path and children
                         return {
-                            v: matchChildren(children, remainingPath, segments)
+                            v: matchChildren(children, remainingPath, segments, consumedPath)
                         };
                     }
                 };
@@ -920,7 +927,9 @@ var RouteNode = function () {
                 var segmentPath = segment.parser.build(params, { ignoreSearch: true });
 
                 return segment.absolute ? segmentPath : path + segmentPath;
-            }, '');
+            }, '')
+            // remove repeated slashes
+            .replace(/\/\/{1,}/g, '/');
 
             var finalPath = path;
 

--- a/dist/umd/route-node.js
+++ b/dist/umd/route-node.js
@@ -765,7 +765,7 @@ var RouteNode = function () {
                 strictQueryParams = options.strictQueryParams,
                 strongMatching = options.strongMatching;
 
-            var matchChildren = function matchChildren(nodes, pathSegment, segments) {
+            var matchChildren = function matchChildren(nodes, pathSegment, segments, consumedBefore) {
                 var isRoot = nodes.length === 1 && nodes[0].name === '';
                 // for (child of node.children) {
 
@@ -775,13 +775,20 @@ var RouteNode = function () {
                     // Partially match path
                     var match = void 0;
                     var remainingPath = void 0;
+                    var segment = pathSegment;
+
+                    if (consumedBefore === '/' && child.path === '/') {
+                        // when we encounter repeating slashes we add the slash
+                        // back to the URL to make it de facto pathless
+                        segment = '/' + pathSegment;
+                    }
 
                     if (!child.children.length) {
-                        match = child.parser.test(pathSegment, { trailingSlash: trailingSlash });
+                        match = child.parser.test(segment, { trailingSlash: trailingSlash });
                     }
 
                     if (!match) {
-                        match = child.parser.partialTest(pathSegment, { delimiter: strongMatching });
+                        match = child.parser.partialTest(segment, { delimiter: strongMatching });
                     }
 
                     if (match) {
@@ -791,13 +798,13 @@ var RouteNode = function () {
                             consumedPath = consumedPath.replace(/\/$/, '');
                         }
 
-                        remainingPath = pathSegment.replace(consumedPath, '');
+                        remainingPath = segment.replace(consumedPath, '');
 
                         if (trailingSlash && !child.children.length) {
                             remainingPath = remainingPath.replace(/^\/\?/, '?');
                         }
 
-                        var search = omit(getSearch(pathSegment.replace(consumedPath, '')), child.parser.queryParams.concat(child.parser.queryParamsBr));
+                        var search = omit(getSearch(segment.replace(consumedPath, '')), child.parser.queryParams.concat(child.parser.queryParamsBr));
                         remainingPath = getPath(remainingPath) + (search ? '?' + search : '');
                         if (trailingSlash && !isRoot && remainingPath === '/' && !/\/$/.test(consumedPath)) {
                             remainingPath = '';
@@ -837,7 +844,7 @@ var RouteNode = function () {
                         }
                         // Else: remaining path and children
                         return {
-                            v: matchChildren(children, remainingPath, segments)
+                            v: matchChildren(children, remainingPath, segments, consumedPath)
                         };
                     }
                 };
@@ -924,7 +931,9 @@ var RouteNode = function () {
                 var segmentPath = segment.parser.build(params, { ignoreSearch: true });
 
                 return segment.absolute ? segmentPath : path + segmentPath;
-            }, '');
+            }, '')
+            // remove repeated slashes
+            .replace(/\/\/{1,}/g, '/');
 
             var finalPath = path;
 

--- a/test/main.js
+++ b/test/main.js
@@ -313,7 +313,6 @@ describe('RouteNode', function () {
         withoutMeta(rootNode.matchPath('/users/list', { trailingSlash: true })).should.eql({name: 'users.list', params: {}});
         withoutMeta(rootNode.matchPath('/users/list')).should.eql({name: 'users.list', params: {}});
         withoutMeta(rootNode.matchPath('/users/list/', { trailingSlash: true })).should.eql({name: 'users.list', params: {}});
-        should.not.exists(rootNode.matchPath('/users/list//', { trailingSlash: true }));
 
         rootNode = getRoutes(true);
         should.not.exists(rootNode.matchPath('/users/list'));
@@ -323,7 +322,6 @@ describe('RouteNode', function () {
         withoutMeta(rootNode.matchPath('/')).should.eql({name: 'default', params: {}});
         withoutMeta(rootNode.matchPath('', { trailingSlash: true })).should.eql({name: 'default', params: {}});
         should.not.exists(rootNode.matchPath('', { trailingSlash: false }));
-        should.not.exists(rootNode.matchPath('/users/list//', { trailingSlash: true }));
     });
 
     it('should match paths with optional trailing slashes and a non-empty root node', function () {
@@ -525,6 +523,36 @@ describe('RouteNode', function () {
         node.buildPath('a.b', {}, { trailingSlash: false }).should.eql('/a');
         node.buildPath('a.b', { c: 1 }, { trailingSlash: false }).should.eql('/a?c=1');
         node.buildPath('c', { c: 1 }, { trailingSlash: false }).should.eql('/?c=1');
+    });
+
+    it('should remove repeated slashes when building paths', ( ) => {
+
+        const node = new RouteNode('', '', [
+            new RouteNode('a', '/', [
+                new RouteNode('b', '/', [
+                    new RouteNode('c', '/')
+                ])
+            ])
+        ]);
+
+        node.buildPath('a.b', {}).should.eql('/');
+        node.buildPath('a.b.c', {}).should.eql('/');
+
+    });
+
+    it('should match paths with repeating slashes', ( ) => {
+
+        const node = new RouteNode('', '', [
+            new RouteNode('a', '/', [
+                new RouteNode('b', '/', [
+                    new RouteNode('c', ':bar')
+                ])
+            ])
+        ]);
+
+        withoutMeta(node.matchPath('/')).should.eql({ name: 'a.b', params: {}});
+        withoutMeta(node.matchPath('/foo')).should.eql({ name: 'a.b.c', params: { bar: 'foo' }});
+
     });
 
 });


### PR DESCRIPTION
As discussed in https://github.com/router5/router5/issues/200, this PR implements support for repeating slashes in paths as a pseudo-implementation of pathless paths. Two changes were made:

- strip repeating slashes in `buildPath`
- when matching paths, if the previously consumed path was a slash, and the current path is a slash as well, prepend a slash to `segmentPath`.