### PR TITLE
Strip content of regexes from path before sorting

### DIFF
--- a/dist/amd/route-node.js
+++ b/dist/amd/route-node.js
@@ -675,8 +675,8 @@ var RouteNode = function () {
                 this.children.push(route);
                 // Push greedy spats to the bottom of the pile
                 this.children.sort(function (left, right) {
-                    var leftPath = left.path.split('?')[0].replace(/(.+)\/$/, '$1');
-                    var rightPath = right.path.split('?')[0].replace(/(.+)\/$/, '$1');
+                    var leftPath = left.path.replace(/<.*?>/g, '').split('?')[0].replace(/(.+)\/$/, '$1');
+                    var rightPath = right.path.replace(/<.*?>/g, '').split('?')[0].replace(/(.+)\/$/, '$1');
                     // '/' last
                     if (leftPath === '/') return 1;
                     if (rightPath === '/') return -1;

--- a/dist/commonjs/route-node.js
+++ b/dist/commonjs/route-node.js
@@ -160,8 +160,8 @@ var RouteNode = function () {
                 this.children.push(route);
                 // Push greedy spats to the bottom of the pile
                 this.children.sort(function (left, right) {
-                    var leftPath = left.path.split('?')[0].replace(/(.+)\/$/, '$1');
-                    var rightPath = right.path.split('?')[0].replace(/(.+)\/$/, '$1');
+                    var leftPath = left.path.replace(/<.*?>/g, '').split('?')[0].replace(/(.+)\/$/, '$1');
+                    var rightPath = right.path.replace(/<.*?>/g, '').split('?')[0].replace(/(.+)\/$/, '$1');
                     // '/' last
                     if (leftPath === '/') return 1;
                     if (rightPath === '/') return -1;

--- a/dist/umd/route-node.js
+++ b/dist/umd/route-node.js
@@ -679,8 +679,8 @@ var RouteNode = function () {
                 this.children.push(route);
                 // Push greedy spats to the bottom of the pile
                 this.children.sort(function (left, right) {
-                    var leftPath = left.path.split('?')[0].replace(/(.+)\/$/, '$1');
-                    var rightPath = right.path.split('?')[0].replace(/(.+)\/$/, '$1');
+                    var leftPath = left.path.replace(/<.*?>/g, '').split('?')[0].replace(/(.+)\/$/, '$1');
+                    var rightPath = right.path.replace(/<.*?>/g, '').split('?')[0].replace(/(.+)\/$/, '$1');
                     // '/' last
                     if (leftPath === '/') return 1;
                     if (rightPath === '/') return -1;

--- a/modules/RouteNode.js
+++ b/modules/RouteNode.js
@@ -109,8 +109,14 @@ export default class RouteNode {
             this.children.push(route);
             // Push greedy spats to the bottom of the pile
             this.children.sort((left, right) => {
-                const leftPath = left.path.split('?')[0].replace(/(.+)\/$/, '$1');
-                const rightPath = right.path.split('?')[0].replace(/(.+)\/$/, '$1');
+                const leftPath = left.path
+                    .replace(/<.*?>/g, '')
+                    .split('?')[0]
+                    .replace(/(.+)\/$/, '$1');
+                const rightPath = right.path
+                    .replace(/<.*?>/g, '')
+                    .split('?')[0]
+                    .replace(/(.+)\/$/, '$1');
                 // '/' last
                 if (leftPath === '/') return 1;
                 if (rightPath === '/') return -1;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/commonjs/route-node.js",
   "jsnext:main": "modules/RouteNode.js",
   "scripts": {
-    "test": "mocha --compilers js:babel-core/register --recursive 'test/main.js'",
+    "test": "mocha --compilers js:babel-core/register --recursive \"test/main.js\"",
     "test:cover": "babel-node node_modules/.bin/isparta cover node_modules/.bin/_mocha -- --recursive 'test/main.js'",
     "lint": "eslint modules/*.js",
     "build:amd": "rollup -c rollup.config.js --format amd",

--- a/test/main.js
+++ b/test/main.js
@@ -554,6 +554,17 @@ describe('RouteNode', function () {
         withoutMeta(node.matchPath('/foo')).should.eql({ name: 'a.b.c', params: { bar: 'foo' }});
 
     });
+    
+    it('should sort path with complex regexes correctly', ( ) => {
+
+        const node = new RouteNode('', '', [
+            new RouteNode('a', '/:path<foo|bar(?:baz?)>/:bar'),
+            new RouteNode('b', '/:foo', )
+        ]);
+
+        withoutMeta(node.matchPath('/foo/bar')).should.eql({ name: 'a', params: { path: 'foo', bar: 'bar' } });
+
+    });
 
 });
 


### PR DESCRIPTION
When a regex contains a question mark (for instance, for an optional parameter, a negative lookahead, or a non-capturing group), the children of the route are not correctly sorted anymore, because they're cut off at the first question mark. This change removes the content of the regex before sorting.

Additionally, I've changed the test command to ensure it runs on Windows as well.