### PR TITLE
Ensure that order of routes that cannot be disambiguated is preserved

### DIFF
--- a/modules/RouteNode.js
+++ b/modules/RouteNode.js
@@ -108,6 +108,9 @@ export default class RouteNode {
 
             this.children.push(route);
             // Push greedy spats to the bottom of the pile
+
+            const originalChildren = this.children.slice(0);
+
             this.children.sort((left, right) => {
                 const leftPath = left.path
                     .replace(/<.*?>/g, '')
@@ -138,8 +141,9 @@ export default class RouteNode {
                 const rightParamLength = (rightPath.split('/').slice(-1)[0] || '').length;
                 if (leftParamLength < rightParamLength) return 1;
                 if (leftParamLength > rightParamLength) return -1;
-                // Same last segment length, preserve definition order
-                return 0;
+                // Same last segment length, preserve definition order. Note that we
+                // cannot just return 0, as sort is not guaranteed to be a stable sort.
+                return originalChildren.indexOf(left) - originalChildren.indexOf(right);
             });
         } else {
             // Locate parent node


### PR DESCRIPTION
Uses the index of the routes in the array of children to disambiguate the order of routes to ensure the sorting is stable.

This solves #15 