### PR TITLE
fix: improve bulk add routes performance

### DIFF
--- a/test/main.js
+++ b/test/main.js
@@ -94,6 +94,17 @@ describe('RouteNode', function() {
         }.should.throw())
     })
 
+    it('should be able to add lots of routes quickly', function() {
+        const root = new RouteNode('', '', [{ name: 'home', path: '/home' }])
+        const routesToAdd = [...Array(1000)].map((_, idx) => ({
+            name: `route_${idx}`,
+            path: `/custom/${idx}`
+        }))
+        root.add(routesToAdd)
+
+        root.children.length.should.equal(1001)
+    })
+
     it('should instanciate a RouteNode object from RouteNode objects', function() {
         const node = new RouteNode('', '', [
             new RouteNode('home', '/home'),


### PR DESCRIPTION
Without this change, the test will timeout. We are adding 500 routes or so in our application and each time a new route is added `sortChildren` is invoked and is slow and gets increasingly slower as new routes are added. This change only invokes `sortChildren` on the final add.

The cb function was removed as it was unused. Let me know if you'd like it back.