### PR TITLE
Perf improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ __node.buildPath(routeName: string, params?: object, options?: BuildOptions): st
 rootNode.buildPath('users.view', {id: 1})     // => "/users/view/1"
 ```
 
+__Performance__
+
+Node children need to be sorted for matching purposes. By default this operation happens after having added all routes.
 
 __matchPath(path: string, options?: MatchOptions): RouteNodeState | null__
 

--- a/modules/RouteNode.ts
+++ b/modules/RouteNode.ts
@@ -165,6 +165,17 @@ export default class RouteNode {
         return this.children.filter(child => !child.absolute)
     }
 
+    public sortChildren() {
+        if (this.children.length) {
+            sortChildren(this.children)
+        }
+    }
+
+    public sortDescendants() {
+        this.sortChildren()
+        this.children.forEach(child => child.sortDescendants())
+    }
+
     public buildPath(
         routeName: string,
         params: object = {},
@@ -255,9 +266,7 @@ export default class RouteNode {
             this.children.push(route)
             // Push greedy spats to the bottom of the pile
 
-            const originalChildren = this.children.slice(0)
-
-            this.children.sort(sortChildren(originalChildren))
+            this.sortChildren()
         } else {
             // Locate parent node
             const segments = this.getSegmentsByName(

--- a/modules/RouteNode.ts
+++ b/modules/RouteNode.ts
@@ -74,7 +74,7 @@ export default class RouteNode {
         childRoutes: Route[] = [],
         cb?: Callback,
         parent?: RouteNode,
-        finalSort?: boolean,
+        finalSort: boolean = true,
         sort?: boolean
     ) {
         this.name = name

--- a/modules/sortChildren.ts
+++ b/modules/sortChildren.ts
@@ -1,6 +1,12 @@
 import RouteNode from './RouteNode'
 
-export default (originalChildren: RouteNode[]) => (
+export default function sortChildren(children: RouteNode[]) {
+    const originalChildren = children.slice(0)
+
+    return children.sort(sortPredicate(originalChildren))
+}
+
+const sortPredicate = (originalChildren: RouteNode[]) => (
     left: RouteNode,
     right: RouteNode
 ): number => {

--- a/test/main.js
+++ b/test/main.js
@@ -55,6 +55,20 @@ describe('RouteNode', function() {
         i.should.not.equal(0)
     })
 
+    it.only('should perform a final sort all routes after adding them', () => {
+        const routes = [...Array(10)].map((_, index) => ({
+            name: `r${index}`,
+            path: `/${index}`,
+            children: [...Array(500)].map((_, childIndex) => ({
+                name: `r${childIndex}`,
+                path: `/${childIndex}`
+            }))
+        }))
+        new RouteNode('', '', routes, undefined, null, true)
+        // No assertion here, if final sort functionality is broken
+        // the test will exceed the 2s timeout and fail
+    })
+
     it('should throw an error when trying to instanciate a RouteNode object with plain objects missing `name` or `path` properties', function() {
         ;(function() {
             new RouteNode('', '', [{ name: 'home' }])


### PR DESCRIPTION
Improve performance improvement by adding a `finalSort` argument to `RouteNode` constructor so sorting of routes (matching order) can be done at the end rather than for each route. Supersedes #22 