### PR TITLE
Fix path with a plus character not matched

### DIFF
--- a/modules/matchChildren.ts
+++ b/modules/matchChildren.ts
@@ -58,10 +58,11 @@ const matchChildren = (
                 consumedPath = consumedPath.replace(/\/$/, '')
             }
 
-            remainingPath = segment.replace(
-                new RegExp('^' + consumedPath, 'i'),
-                ''
-            )
+            // Can't create a regexp from the path because it might contain a
+            // regexp character.
+            if (segment.toLowerCase().indexOf(consumedPath.toLowerCase()) === 0) {
+                remainingPath = segment.slice(consumedPath.length)
+            }
 
             if (!strictTrailingSlash && !child.children.length) {
                 remainingPath = remainingPath.replace(/^\/\?/, '?')

--- a/test/main.js
+++ b/test/main.js
@@ -763,6 +763,26 @@ describe('RouteNode', function() {
             c: ['1']
         })
     })
+
+    it('should match path with a plus character', () => {
+        const routes = [
+            {
+                name: 'page',
+                path: '/:name<.+>/:id<(\\w{2}[0-9]{4})>.html'
+            }
+        ]
+        const options = {
+            allowNotFound: true,
+            trailingSlashMode: 'never',
+            queryParamsMode: 'loose',
+            queryParams: {nullFormat: 'hidden'}
+        }
+        const node = new RouteNode('', '', routes)
+        node.matchPath('/foo+bar/AB1234.html', options).params.should.eql({
+            id: 'AB1234',
+            name: 'foo+bar'
+        })
+    })
 })
 
 function getRoutes(trailingSlash) {

--- a/test/main.js
+++ b/test/main.js
@@ -55,7 +55,7 @@ describe('RouteNode', function() {
         i.should.not.equal(0)
     })
 
-    it.only('should perform a final sort all routes after adding them', () => {
+    it('should perform a final sort all routes after adding them', () => {
         const routes = [...Array(10)].map((_, index) => ({
             name: `r${index}`,
             path: `/${index}`,


### PR DESCRIPTION
The root cause for the problem is that when `consumedPath` contains a regexp character, then the regexp `new RegExp('^' + consumedPath, 'i')` doesn't match `segment`.

For example when `consumedPath` is `/foo+bar` then the regexp is `^/foo+bar` and that doesn't match to `"/foo+bar"`. So it is better to avoid the use of regexp here so we don't need to escape user input.