### PR TITLE
Fix TypeError when there is no match for path

### DIFF
--- a/modules/matchChildren.ts
+++ b/modules/matchChildren.ts
@@ -60,8 +60,12 @@ const matchChildren = (
 
             // Can't create a regexp from the path because it might contain a
             // regexp character.
-            if (segment.toLowerCase().indexOf(consumedPath.toLowerCase()) === 0) {
+            if (
+                segment.toLowerCase().indexOf(consumedPath.toLowerCase()) === 0
+            ) {
                 remainingPath = segment.slice(consumedPath.length)
+            } else {
+                remainingPath = segment
             }
 
             if (!strictTrailingSlash && !child.children.length) {

--- a/test/main.js
+++ b/test/main.js
@@ -775,13 +775,27 @@ describe('RouteNode', function() {
             allowNotFound: true,
             trailingSlashMode: 'never',
             queryParamsMode: 'loose',
-            queryParams: {nullFormat: 'hidden'}
+            queryParams: { nullFormat: 'hidden' }
         }
         const node = new RouteNode('', '', routes)
         node.matchPath('/foo+bar/AB1234.html', options).params.should.eql({
             id: 'AB1234',
             name: 'foo+bar'
         })
+    })
+
+    it('should return null if there is no match', () => {
+        const routes = [
+            {
+                name: 'page',
+                path: '/:name<.+>'
+            }
+        ]
+        const options = {
+            allowNotFound: true
+        }
+        const node = new RouteNode('', '', routes)
+        should(node.matchPath('/foobar%24', options)).be.null()
     })
 })
 


### PR DESCRIPTION
Fixes a regression introduced in #24. Line 68 threw a `TypeError: Cannot read property 'replace' of undefined` when the path didn't match a segment above it.