### PR TITLE
feat: clearer support for language prefixes

### DIFF
--- a/src/matchChildren.ts
+++ b/src/matchChildren.ts
@@ -27,7 +27,7 @@ const matchChildren = (
     let remainingPath
     let segment = pathSegment
 
-    if (consumedBefore === '/' && child.path === '/') {
+    if (consumedBefore === '/' && child.path[0] === '/') {
       // when we encounter repeating slashes we add the slash
       // back to the URL to make it de facto pathless
       segment = '/' + pathSegment

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -868,6 +868,66 @@ describe('RouteNode', function() {
       })
     })
   })
+
+  describe('lang prefixes', () => {
+    const mainNodes = [
+      new RouteNode('default', '/'),
+      new RouteNode('home', '/home'),
+      new RouteNode('user', '/user', [
+        new RouteNode('default', '/'),
+        new RouteNode('orders', '/orders'),
+        new RouteNode('reviews', '/review/:page')
+      ])
+    ]
+    const enNode = new RouteNode('en', '/', mainNodes)
+    const ruNode = new RouteNode('ru', '/ru', mainNodes)
+    const koNode = new RouteNode('ko', '/ko', mainNodes)
+    const appNodes = new RouteNode('', '', [enNode, ruNode, koNode])
+
+    it('should match prefix-less path (en-lang)', () => {
+      expect(appNodes.matchPath('/')).toEqual({
+        name: 'en.default',
+        params: {},
+        meta: { en: {}, 'en.default': {} }
+      })
+      expect(appNodes.matchPath('/user')).toEqual({
+        name: 'en.user.default',
+        params: {},
+        meta: { en: {}, 'en.user': {}, 'en.user.default': {} }
+      })
+      expect(appNodes.matchPath('/user/')).toEqual({
+        name: 'en.user.default',
+        params: {},
+        meta: { en: {}, 'en.user': {}, 'en.user.default': {} }
+      })
+      expect(
+        appNodes.matchPath('/user/orders/', { strictTrailingSlash: true })
+      ).toEqual(null)
+    })
+
+    it('should match path witl lang prefix (ko-lang)', () => {
+      expect(appNodes.matchPath('/ko')).toEqual({
+        name: 'ko.default',
+        params: {},
+        meta: { ko: {}, 'ko.default': {} }
+      })
+      expect(appNodes.matchPath('/ko/user/orders?page=1')).toEqual({
+        name: 'ko.user.orders',
+        params: { page: '1' },
+        meta: { ko: {}, 'ko.user': {}, 'ko.user.orders': {} }
+      })
+      expect(appNodes.matchPath('/ko/user/orders/?page=1')).toEqual({
+        name: 'ko.user.orders',
+        params: { page: '1' },
+        meta: { ko: {}, 'ko.user': {}, 'ko.user.orders': {} }
+      })
+      expect(
+        appNodes.matchPath('/ko/user/orders/?page=1', {
+          strictTrailingSlash: true
+        })
+      ).toEqual(null)
+    })
+  })
 })
 
 function getRoutes(trailingSlash?: boolean) {


### PR DESCRIPTION
If project have to use subdirectories (lang prefixes), like:
`example.com/user` - for English
`example.com/de/user` - for German
`example.com/ko/user` - for Korean

We will face some problems:
if `/user` node is children of `/` node as well as children of `/ko` node.
When code will try to find a match for `/user` by going through `/` node, it will slice `/` from `/user` segment, so at the next iteration code will try to find a match for `user` instead of `/user`, thus will return `null` as result.

So my proposal is to change literally one line of code, this shouldn't break anything, if i understand everything right.

